### PR TITLE
Immediate origin is not always a routing number

### DIFF
--- a/src/Nacha/Record/FileHeader.php
+++ b/src/Nacha/Record/FileHeader.php
@@ -47,7 +47,12 @@ class FileHeader {
 		return $this;
 	}
 	public function setImmediateOrigin($immediateOrigin) {
-		$this->immediateOrigin = new RoutingNumber($immediateOrigin);
+		if(strlen($immediateOrigin) == 9) {
+			$this->immediateOrigin = new RoutingNumber($immediateOrigin);
+		}
+		else {
+			$this->immediateOrigin = new Number($immediateOrigin, 10);
+		}
 		return $this;
 	}
 	public function setFileCreationDate($fileCreationDate) {
@@ -88,10 +93,13 @@ class FileHeader {
 	}
 
 	public function __toString() {
+		$origin = $this->immediateOrigin instanceof RoutingNumber ? (' ' . $this->immediateOrigin) :
+			$this->immediateOrigin;
+
 		return $this->recordTypeCode.
 			$this->priorityCode.
 			' '.$this->immediateDestination. // Prefixed with a space
-			' '.$this->immediateOrigin.      // Prefixed with a space
+			$origin.
 			$this->fileCreationDate.
 			$this->fileCreationTime.
 			$this->fileIdModifier.


### PR DESCRIPTION
Immediate origin is not always a routing number. It can be a number assigned by the origin bank to identify the sender. Often an EIN preceded by a particular number like 1. If that is the case, There will be no space preceding the immediate origin number.
