### PR TITLE
Rename String class to StringHelper for php 7 compatibility

### DIFF
--- a/src/Nacha/Field/CompanyEntryDescription.php
+++ b/src/Nacha/Field/CompanyEntryDescription.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Field;
 
-class CompanyEntryDescription extends String {
+class CompanyEntryDescription extends StringHelper {
 
 	// upper case trigger words
 	private $triggers = ["reversal", "reclaim", "nonsettled", "autoenroll", "redepcheck", "no check", "return fee", "hcclaimpmt"];

--- a/src/Nacha/Field/CompanyName.php
+++ b/src/Nacha/Field/CompanyName.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Field;
 
-class CompanyName extends String {
+class CompanyName extends StringHelper {
 
 	public function __construct($value) {
 		$value = strtolower($value) == 'check destroyed' ? strtoupper($value) : $value;

--- a/src/Nacha/Field/FileIdModifier.php
+++ b/src/Nacha/Field/FileIdModifier.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Field;
 
-class FileIdModifier extends String {
+class FileIdModifier extends StringHelper {
 	public function __construct($value) {
 		parent::__construct(strtoupper($value), 1);
 

--- a/src/Nacha/Field/StandardEntryClass.php
+++ b/src/Nacha/Field/StandardEntryClass.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Field;
 
-class StandardEntryClass extends String {
+class StandardEntryClass extends StringHelper {
 
 	const ACK = 'ACK';
 	const ADV = 'ADV';

--- a/src/Nacha/Field/StringHelper.php
+++ b/src/Nacha/Field/StringHelper.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Field;
 
-class String {
+class StringHelper {
 
 	protected $value;
 	protected $length;

--- a/src/Nacha/Record/BatchFooter.php
+++ b/src/Nacha/Record/BatchFooter.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Record;
 
-use Nacha\Field\String;
+use Nacha\Field\StringHelper;
 use Nacha\Field\Number;
 
 class BatchFooter {
@@ -21,7 +21,7 @@ class BatchFooter {
 
 	public function __construct() {
 		// defaults/optional
-		$this->reserved = new String('', 6);
+		$this->reserved = new StringHelper('', 6);
 		$this->setEntryAddendaCount(0);
 		$this->setMessageAuthenticationCode('');
 		$this->setTotalDebitAmount(0);
@@ -53,7 +53,7 @@ class BatchFooter {
 		return $this;
 	}
 	public function setMessageAuthenticationCode($messageAuthenticationCode) {
-		$this->messageAuthenticationCode = new String($messageAuthenticationCode, 19);
+		$this->messageAuthenticationCode = new StringHelper($messageAuthenticationCode, 19);
 		return $this;
 	}
 	public function setOriginatingDfiId($originatingDfiId) {

--- a/src/Nacha/Record/BatchHeader.php
+++ b/src/Nacha/Record/BatchHeader.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Record;
 
-use Nacha\Field\String;
+use Nacha\Field\StringHelper;
 use Nacha\Field\Number;
 use Nacha\Field\CompanyName;
 use Nacha\Field\StandardEntryClass;
@@ -83,11 +83,11 @@ class BatchHeader {
 		return $this;
 	}
 	public function setCompanyDiscretionaryData($companyDiscretionaryData) {
-		$this->companyDiscretionaryData = new String($companyDiscretionaryData, 20);
+		$this->companyDiscretionaryData = new StringHelper($companyDiscretionaryData, 20);
 		return $this;
 	}
 	public function setCompanyId($companyId) {
-		$this->companyId = new String($companyId, 10);
+		$this->companyId = new StringHelper($companyId, 10);
 		return $this;
 	}
 	public function setStandardEntryClassCode($standardEntryClassCode) {
@@ -99,15 +99,15 @@ class BatchHeader {
 		return $this;
 	}
 	public function setCompanyDescriptiveDate($companyDescriptiveDate) {
-		$this->companyDescriptiveDate = new String($companyDescriptiveDate, 6);
+		$this->companyDescriptiveDate = new StringHelper($companyDescriptiveDate, 6);
 		return $this;
 	}
 	public function setEffectiveEntryDate($effectiveEntryDate) {
-		$this->effectiveEntryDate = new String($effectiveEntryDate, 6);
+		$this->effectiveEntryDate = new StringHelper($effectiveEntryDate, 6);
 		return $this;
 	}
 	public function setSettlementDate($settlementDate) {
-		$this->settlementDate = new String($settlementDate, 3);
+		$this->settlementDate = new StringHelper($settlementDate, 3);
 		return $this;
 	}
 	public function setOriginatorStatusCode($originatorStatusCode) {
@@ -115,7 +115,7 @@ class BatchHeader {
 		return $this;
 	}
 	public function setOriginatingDFiId($originatingDFiId) {
-		$this->originatingDFiId = new String($originatingDFiId, 8);
+		$this->originatingDFiId = new StringHelper($originatingDFiId, 8);
 		return $this;
 	}
 	public function setBatchNumber($batchNumber) {

--- a/src/Nacha/Record/CcdEntry.php
+++ b/src/Nacha/Record/CcdEntry.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Record;
 
-use Nacha\Field\String;
+use Nacha\Field\StringHelper;
 use Nacha\Field\Number;
 
 // Cash Collection and Disbursement Entry (CCD)
@@ -48,19 +48,19 @@ class CcdEntry extends Entry {
 		return $this;
 	}
 	public function setReceivingDFiAccountNumber($receivingDFiAccountNumber) {
-		$this->receivingDFiAccountNumber = new String($receivingDFiAccountNumber, 17);
+		$this->receivingDFiAccountNumber = new StringHelper($receivingDFiAccountNumber, 17);
 		return $this;
 	}
 	public function setReceivingCompanyId($receivingCompanyId) {
-		$this->receivingCompanyId = new String($receivingCompanyId, 15);
+		$this->receivingCompanyId = new StringHelper($receivingCompanyId, 15);
 		return $this;
 	}
 	public function setReceivingCompanyName($receivingCompanyName) {
-		$this->receivingCompanyName = new String($receivingCompanyName, 22);
+		$this->receivingCompanyName = new StringHelper($receivingCompanyName, 22);
 		return $this;
 	}
 	public function setDiscretionaryData($discretionaryData) {
-		$this->discretionaryData = new String($discretionaryData, 2);
+		$this->discretionaryData = new StringHelper($discretionaryData, 2);
 		return $this;
 	}
 	public function setAddendaRecordIndicator($addendaRecordIndicator) {

--- a/src/Nacha/Record/DebitEntry.php
+++ b/src/Nacha/Record/DebitEntry.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Record;
 
-use Nacha\Field\String;
+use Nacha\Field\StringHelper;
 use Nacha\Field\Number;
 
 // PPD, TEL, WEB debit
@@ -48,19 +48,19 @@ class DebitEntry extends Entry {
 		return $this;
 	}
 	public function setDFiAccountNumber($dFiAccountNumber) {
-		$this->dFiAccountNumber = new String($dFiAccountNumber, 17);
+		$this->dFiAccountNumber = new StringHelper($dFiAccountNumber, 17);
 		return $this;
 	}
 	public function setIndividualId($individualId) {
-		$this->individualId = new String($individualId, 15);
+		$this->individualId = new StringHelper($individualId, 15);
 		return $this;
 	}
 	public function setIdividualName($idividualName) {
-		$this->idividualName = new String($idividualName, 22);
+		$this->idividualName = new StringHelper($idividualName, 22);
 		return $this;
 	}
 	public function setDiscretionaryData($discretionaryData) {
-		$this->discretionaryData = new String($discretionaryData, 2);
+		$this->discretionaryData = new StringHelper($discretionaryData, 2);
 		return $this;
 	}
 	public function setAddendaRecordIndicator($addendaRecordIndicator) {

--- a/src/Nacha/Record/FileFooter.php
+++ b/src/Nacha/Record/FileFooter.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Record;
 
-use Nacha\Field\String;
+use Nacha\Field\StringHelper;
 use Nacha\Field\Number;
 
 class FileFooter {
@@ -18,7 +18,7 @@ class FileFooter {
 
 	public function __construct() {
 		// defaults
-		$this->reserved = new String('', 39);
+		$this->reserved = new StringHelper('', 39);
 		$this->setBatchCount(0);
 		$this->setBlockCount(0);
 		$this->setEntryAddendaCount(0);

--- a/src/Nacha/Record/FileHeader.php
+++ b/src/Nacha/Record/FileHeader.php
@@ -2,7 +2,7 @@
 
 namespace Nacha\Record;
 
-use Nacha\Field\String;
+use Nacha\Field\StringHelper;
 use Nacha\Field\Number;
 use Nacha\Field\RoutingNumber;
 use Nacha\Field\FileIdModifier;
@@ -56,11 +56,11 @@ class FileHeader {
 		return $this;
 	}
 	public function setFileCreationDate($fileCreationDate) {
-		$this->fileCreationDate = new String($fileCreationDate, 6);
+		$this->fileCreationDate = new StringHelper($fileCreationDate, 6);
 		return $this;
 	}
 	public function setFileCreationTime($fileCreationTime) {
-		$this->fileCreationTime = new String($fileCreationTime, 4);
+		$this->fileCreationTime = new StringHelper($fileCreationTime, 4);
 		return $this;
 	}
 	public function setFileIdModifier($fileIdModifier) {
@@ -80,15 +80,15 @@ class FileHeader {
 		return $this;
 	}
 	public function setImmediateDestinationName($immediateDestinationName) {
-		$this->immediateDestinationName = new String($immediateDestinationName, 23);
+		$this->immediateDestinationName = new StringHelper($immediateDestinationName, 23);
 		return $this;
 	}
 	public function setImmediateOriginName($immediateOriginName) {
-		$this->immediateOriginName = new String($immediateOriginName, 23);
+		$this->immediateOriginName = new StringHelper($immediateOriginName, 23);
 		return $this;
 	}
 	public function setReferenceCode($referenceCode) {
-		$this->referenceCode = new String($referenceCode, 8);
+		$this->referenceCode = new StringHelper($referenceCode, 8);
 		return $this;
 	}
 

--- a/test/Nacha/Field/StringTest.php
+++ b/test/Nacha/Field/StringTest.php
@@ -6,7 +6,7 @@ class StringTest extends \PHPUnit_Framework_TestCase {
 
 	public function testPadding() {
 		// given
-		$str = new String('Hello World', 32);
+		$str = new StringHelper('Hello World', 32);
 
 		// then
 		$this->assertEquals('Hello World                     ', (string)$str);
@@ -14,7 +14,7 @@ class StringTest extends \PHPUnit_Framework_TestCase {
 
 	public function testOptional() {
 		// given
-		$str = new String('', 10);
+		$str = new StringHelper('', 10);
 
 		// then
 		$this->assertEquals('          ', (string)$str);
@@ -29,7 +29,7 @@ class StringTest extends \PHPUnit_Framework_TestCase {
 		}
 
 		// when
-		$str = new String($allValidAsciiChars, strlen($allValidAsciiChars));
+		$str = new StringHelper($allValidAsciiChars, strlen($allValidAsciiChars));
 
 		// then
 		$this->assertEquals($allValidAsciiChars, (string)$str);
@@ -39,7 +39,7 @@ class StringTest extends \PHPUnit_Framework_TestCase {
 	 * @expectedException \Nacha\Field\InvalidFieldException
 	 */
 	public function testNotString() {
-		new String(12, 32);
+		new StringHelper(12, 32);
 	}
 
 	public function testInvalidCharacter() {
@@ -48,7 +48,7 @@ class StringTest extends \PHPUnit_Framework_TestCase {
 			$invalid = 'validtext'.chr($ascii);
 
 			try {
-				new String($invalid, strlen($invalid));
+				new StringHelper($invalid, strlen($invalid));
 
 				$this->assertTrue(false, 'Should throw an exception for invalid ASCII:'.$ascii);
 


### PR DESCRIPTION
In php 7 and above, classes were added for primitives like String and those keywords are now reserved. This has necessitated updating many projects to name their String classes something else. I've generally seen StringHelper and used that here for consistency.